### PR TITLE
fix: ensure transformers models load from CDN

### DIFF
--- a/src/pages/App.jsx
+++ b/src/pages/App.jsx
@@ -16,6 +16,11 @@ async function getTransformers() {
       // @vite-ignore prevents Vite from trying to pre-bundle external URL
       const mod = await import(/* @vite-ignore */ url)
       const { env } = mod
+      // Always load models from remote (HF/CDN) to avoid parsing SPA HTML as JSON
+      // See issue: fetching local model path would hit index.html and cause
+      // "Unexpected token '<'" when Transformers.js expects JSON files.
+      if (env) env.allowLocalModels = false
+
       // Compute wasm path relative to the loaded script location
       const base = new URL('./', url).toString()
       const wasmPath = new URL('wasm/', base).toString()


### PR DESCRIPTION
## Summary
- disable local model lookup so Transformers.js fetches remote ONNX models and avoids HTML/JSON parse errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6d3c6449c83218411275e3ce37655